### PR TITLE
feat: add role-based navbar visibility using JWT decoding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "jwt-decode": "^4.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.0"
@@ -2190,6 +2191,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jwt-decode": "^4.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.0"

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { getUserRole } from "../services/auth";
 
 const links = [
   { key: "dashboard",   label: "Dashboard",    path: "/dashboard" },
   { key: "inventory",   label: "Inventory",    path: "/inventory" },
   { key: "transactions",label: "Transactions", path: "/transactions" },
-  { key: "users",       label: "Users",        path: "/users" },
+  { key: "users", label: "Users", path: "/users", role: "ADMIN" },
   { key: "reports",     label: "Reports",      path: "/reports" },
 ];
 
@@ -13,6 +14,7 @@ export default function Navbar() {
   const navigate = useNavigate();
   const location = useLocation();
   const pathname = location.pathname.toLowerCase();
+  const role = getUserRole();
 
   return (
     <div style={wrap}>
@@ -23,20 +25,22 @@ export default function Navbar() {
 
       <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
         <nav aria-label="Primary" style={{ display: "flex", gap: 20 }}>
-          {links.map((l) => {
-            const isActive =
-              l.path === "/"
-                ? pathname === "/"
-                : pathname.startsWith(l.path.toLowerCase());
-            return (
-              <button
-                key={l.key}
-                onClick={() => navigate(l.path)}
-                style={navLink(isActive)}
-                aria-current={isActive ? "page" : undefined}
-              >
-                {l.label}
-              </button>
+          {links
+            .filter((l) => !l.role || l.role === role) // 👈 filter by role
+            .map((l) => {
+              const isActive =
+                l.path === "/"
+                  ? pathname === "/"
+                  : pathname.startsWith(l.path.toLowerCase());
+              return (
+                <button
+                  key={l.key}
+                  onClick={() => navigate(l.path)}
+                  style={navLink(isActive)}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {l.label}
+                </button>
             );
           })}
         </nav>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -8,6 +8,7 @@ function authHeaders(extraHeaders = {}) {
   };
 }
 
+
 export const api = {
   async login({ email, password }) {
     const res = await fetch('/auth/login', {

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,0 +1,14 @@
+// src/service/auth.js
+import { jwtDecode } from "jwt-decode";
+
+export function getUserRole() {
+  const token = localStorage.getItem("token");
+  if (!token) return null;
+  try {
+    const decoded = jwtDecode(token);
+    return decoded.role || null;
+  } catch (err) {
+    console.error("Invalid token:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
- Implemented getUserRole() helper in auth.js using jwt-decode
- Navbar now conditionally shows admin pages only for users with 'admin' role